### PR TITLE
mudança na foto do registro

### DIFF
--- a/app/Http/Controllers/RegistroController.php
+++ b/app/Http/Controllers/RegistroController.php
@@ -84,6 +84,6 @@ class RegistroController extends Controller
         $this->authorize('admin');
         $registroId = explode('/', url()->current())[4];
         $registro = Registro::find($registroId);
-        return Storage::download('/pictures/' . $registro->image);
+        return Storage::download('' . $registro->image);
     }
 }

--- a/resources/views/registros/show.blade.php
+++ b/resources/views/registros/show.blade.php
@@ -20,5 +20,4 @@
         <img src="/registros/{{ $registro->id }}/picture" class="rounded img-thumbnail p-3 mt-3" alt="Foto">
     </div>
 </div>
-
 @endsection


### PR DESCRIPTION
Antes, quando clicava no registro de entrada ou saída de algum monitor, a foto tirada não aparecia. Isso era por conta da busca em uma pasta chamada 'pictures' que não existe. Por conta disso o caminho /pictures foi apagado e agora a foto aparece normalmente.