### PR TITLE
Arrumando a view para que mostre o index da maneira correta

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -23,11 +23,9 @@
                         @if ($registro->type == 'in')
                             <i class="fas fa-sign-in-alt text-success"></i> {{ $registro->created_at->format('H:i') }} (Entrada)
                             - {{ \Uspdev\Replicado\Pessoa::obterNome($registro->codpes) }}
-                        @elseif ($registro->type == 'out' && Auth::check())
+                        @elseif ($registro->type == 'out')
                             <i class="fas fa-sign-in-alt text-danger"></i> {{ $registro->created_at->format('H:i') }} (Saída)
                             - {{ \Uspdev\Replicado\Pessoa::obterNome($registro->codpes) }}
-                        @else
-                            Não há monitor(a) no local
                         @endif
 
                         {{-- Se foi parametrizado para mostrar foto do monitor --}}


### PR DESCRIPTION
Foi tirada a condição "else" que acarretava na exibição incorreta da página e os registros da saída agora podem ser vistos sem estar logado.