### PR TITLE
Quando bolsista considerar o último dia do mês

### DIFF
--- a/app/Http/Controllers/GrupoController.php
+++ b/app/Http/Controllers/GrupoController.php
@@ -14,7 +14,7 @@ class GrupoController extends Controller
      */
     public function index()
     {
-        $this->authorize('admin');
+        $this->authorize('boss');
 
         $grupos = Grupo::all();
 
@@ -60,7 +60,7 @@ class GrupoController extends Controller
      */
     public function show(Grupo $grupo)
     {
-        $this->authorize('admin');
+        $this->authorize('boss');
         //
     }
 
@@ -72,7 +72,7 @@ class GrupoController extends Controller
      */
     public function edit(Grupo $grupo)
     {
-        $this->authorize('admin');
+        $this->authorize('boss');
         return view('grupos.edit', [
                 'grupo' => $grupo,
             ]);
@@ -87,7 +87,7 @@ class GrupoController extends Controller
      */
     public function update(GrupoRequest $request, Grupo $grupo)
     {
-        $this->authorize('admin');
+        $this->authorize('boss');
         $validated = $request->validated();
         $grupo->update($validated);
         request()->session()->flash('alert-info','Grupo atualizado com sucesso');

--- a/app/Http/Controllers/PessoaController.php
+++ b/app/Http/Controllers/PessoaController.php
@@ -13,7 +13,7 @@ use App\Models\Registro;
 use App\Models\Grupo;
 
 use App\Utils\Util;
-
+use Illuminate\Support\Facades\Auth;
 
 class PessoaController extends Controller
 {
@@ -47,11 +47,32 @@ class PessoaController extends Controller
                 'out' => 'required|date_format:d/m/Y'
             ]);
         } else {
+            // Verificar o início e fim da folha no Grupo que a pessoa pertence
+            $inicio_folha = (Grupo::getGroup($pessoa['codpes'])) ? Grupo::getGroup($pessoa['codpes'])->inicio_folha : 21;
+            $fim_folha = (Grupo::getGroup($pessoa['codpes'])) ? Grupo::getGroup($pessoa['codpes'])->fim_folha : 20;   
+            // Formato dia com dois dígitos
+            $inicio_folha = (strlen($inicio_folha) < 2) ? '0' . $inicio_folha : $inicio_folha;
+            $fim_folha = (strlen($fim_folha) < 2) ? '0' . $fim_folha : $fim_folha;
 	        // Se o dia corrente é dia 31, não estava subtraindo 1 mês em $request->in
             // https://stackoverflow.com/questions/9058523/php-date-and-strtotime-return-wrong-months-on-31st Answer #31
-            $base = strtotime(date('Y-m',time()) . '-01 00:00:01');
-            $request->in = '21/' . date('m/Y', strtotime('-1 month', $base));
-            $request->out = "20/" . date("m/Y");
+            $base = strtotime(date('Y-m', time()) . '-01 00:00:01'); 
+            if ($inicio_folha == 1) {
+                // Bolsistas Pró-Aluno, inicia dia 1º e vai até o último dia do mês
+                $request->in = $inicio_folha . '/' . date('m/Y');
+                $request->out = Carbon::createFromFormat('d/m/Y', $request->in)->modify('last day of this month')->format('d/m/Y');
+            } else {
+                // Estagiários setores, inicia dia 21 e vai até o dia 20 do outro mês
+                // Se o dia corrente é menor ou igual ao dia de fim da folha, ex.: data corrente 01/12/2023, trazer início 21/11/2023 à 20/12/2023
+                if (now()->format('d') <= $fim_folha) {
+                    // Diminui 1 mês na data de início da folha
+                    $request->in = $inicio_folha . '/' . date('m/Y', strtotime('-1 month', $base));
+                    $request->out = $fim_folha . '/' . date("m/Y");
+                } else { 
+                    // Aumenta 1 mês na data de fim da folha
+                    $request->in = $inicio_folha . '/' . date('m/Y');
+                    $request->out = $fim_folha . '/' . date("m/Y", strtotime('+1 month', $base));
+                }
+            }
         }
 
         $in = Carbon::createFromFormat('d/m/Y H:i:s', $request->in . ' 00:00:00');

--- a/config/laravel-usp-theme.php
+++ b/config/laravel-usp-theme.php
@@ -31,7 +31,7 @@ $menu = [
             [
                 'text' => 'Grupos',
                 'url'  => '/grupos',
-                'can' => 'admin',
+                'can' => 'boss',
             ],
         ],
     ],

--- a/resources/views/grupos/index.blade.php
+++ b/resources/views/grupos/index.blade.php
@@ -19,21 +19,31 @@
         </tr>
       </thead>
       <tbody>
-        @foreach($grupos as $grupo)
+      @foreach($grupos as $grupo)
+
+        {{-- Se o usuário logado é supervisor, autorizador ou admin, lista o grupo --}}
+        @if (App\Models\Grupo::find($grupo->id)->codpes_supervisor == Auth::user()->codpes || App\Models\Grupo::find($grupo->id)->codpes_autorizador == Auth::user()->codpes || Gate::allows('admin')) 
+
         <tr>
           <td>{{ $grupo->name }}</td>
           <td>{{ $grupo->codpes_supervisor }}</td>
           <td>{{ $grupo->codpes_autorizador }}</td>
           <td align="center">
             <a href="/grupos/{{$grupo->id}}/edit"><i class="fas fa-pencil-alt" color="#007bff"></i></a>
+              @can ('admin')
               <form method="POST" action="/grupos/{{$grupo->id}}/">
                 @csrf
                 @method('delete')
                 <button type="submit" onclick="return confirm('Tem certeza que deseja excluir esse grupo?');" style="background-color: transparent;border: none;"><i class="far fa-trash-alt" color="#007bff"></i></button>
               </form>
+              @endcan
           </td>   
         </tr>
+        
+        @endif
+        
       @endforeach
+
       </tbody>
     </table>  
 </div>

--- a/resources/views/grupos/partials/form.blade.php
+++ b/resources/views/grupos/partials/form.blade.php
@@ -13,7 +13,7 @@
 
     <br> <br>
     <label for="query">Query:</label>
-    <textarea class="form-control" id="query" rows="3" name="query">{{ old('query', $grupo->query) }}</textarea>
+    <textarea class="form-control" id="query" rows="3" name="query" @if (!Gate::allows('admin')) readonly @endif>{{ old('query', $grupo->query) }}</textarea>
     <br>
 
     <label for="fim_folha">Dia que início da folha de pagamento:</label>


### PR DESCRIPTION
Com isso, uma vez cadastrado o fim de folha com dia 31, não será mais necessário editar este grupo a cada mês, independente se o mês termina em 28, 30 ou 31.

Fix #39 